### PR TITLE
Report Error when Tasty Inspector is used with a Scala2 class

### DIFF
--- a/compiler/src/dotty/tools/dotc/fromtasty/AlreadyLoadedCompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/AlreadyLoadedCompilationUnit.scala
@@ -7,4 +7,7 @@ import dotty.tools.dotc.util.NoSource
  *  encountered, and attempted to inspect, something that has already been loaded, for example a Scala primitive or a
  *  library class like Option.
  */
-class AlreadyLoadedCompilationUnit(val className: String) extends CompilationUnit(NoSource)
+class AlreadyLoadedCompilationUnit(val className: String) extends CompilationUnit(NoSource) {
+  override def toString(): String = s"AlreadyLoadedCompilationUnit(${className})"
+}
+


### PR DESCRIPTION
relates to ampepfl   dotty/issues/12669

worked on this with Nicholas Stucki and Matt Bovel last 2 sprints. 

From what I understand the Array class is a scala2 class and the TastyReader shouldn't be trying to ready tasty files for it.
However, one thing that's not clear is how the tasty file in the issue was generated since Tasty files are not generated for scala2 classes.

Another thing that's not addressed here is testing - given that we don't want to check in the tasty file into the repo - we'd need to generate them while running the tests, and it's not clear how to do that.
